### PR TITLE
Don't truncate error messages

### DIFF
--- a/src/sentry/eventtypes/error.py
+++ b/src/sentry/eventtypes/error.py
@@ -26,5 +26,5 @@ class ErrorEvent(BaseEvent):
             return metadata['type']
         return u'{}: {}'.format(
             metadata['type'],
-            truncatechars(metadata['value'].splitlines()[0], 100),
+            metadata['value'].splitlines()[0],
         )


### PR DESCRIPTION
The truncation removes the error message from the slack notification.